### PR TITLE
Fix return signature of firebase_v5.x.x.js signInWithEmailAndPassword

### DIFF
--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -125,7 +125,7 @@ declare class $npm$firebase$auth$Auth {
   signInWithEmailAndPassword(
     email: string,
     password: string
-  ): Promise<$npm$firebase$auth$User>;
+  ): Promise<$npm$firebase$auth$UserCredential>;
   signInWithPhoneNumber(
     phoneNumber: string,
     applicationVerifier: $npm$firebase$auth$ApplicationVerifier


### PR DESCRIPTION
signInWithEmailAndPassword should return Promise<$npm$firebase$auth$UserCredential>
see https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signInWithEmailAndPassword